### PR TITLE
bugfix

### DIFF
--- a/extensions/vscode/tree-sitter/code-snippet-queries/javascript.scm
+++ b/extensions/vscode/tree-sitter/code-snippet-queries/javascript.scm
@@ -1,12 +1,10 @@
 (
-  (comment)? @comment
   (class_declaration
     name: (_) @name
   ) @definition
 )
 
 (
-  (comment)? @comment
   (function_declaration
     name: (_) @name
     parameters: (_) @parameters
@@ -14,7 +12,6 @@
 )
 
 (
-  (comment)? @comment
   (method_definition
     name: (_) @name
     parameters: (_) @parameters

--- a/extensions/vscode/tree-sitter/code-snippet-queries/typescript.scm
+++ b/extensions/vscode/tree-sitter/code-snippet-queries/typescript.scm
@@ -1,12 +1,10 @@
 (
-  (comment)? @comment
   (class_declaration
     name: (_) @name
   ) @definition
 )
 
 (
-  (comment)? @comment
   (function_declaration
     name: (_) @name
     parameters: (_) @parameters
@@ -14,7 +12,6 @@
 )
 
 (
-  (comment)? @comment
   (method_definition
     name: (_) @name
     parameters: (_) @parameters
@@ -22,7 +19,6 @@
 )
 
 (
-  (comment)? @comment
   (interface_declaration
     name: (_) @name) @definition
 ) 


### PR DESCRIPTION
remove comment prefix from javascript and typescript .scm to avoid tree-sitter getting stuck
https://github.com/continuedev/continue/issues/3753#issuecomment-3224977558

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
